### PR TITLE
Add support for data URIs.

### DIFF
--- a/lifecycle/modules/apps/docker/adapter.py
+++ b/lifecycle/modules/apps/docker/adapter.py
@@ -14,7 +14,8 @@ Created on 09 feb. 2018
 import lifecycle.modules.apps.docker.client as docker_client
 import common.common as common
 import lifecycle.data.db as db
-import sys, traceback, wget, uuid, os, time
+import sys, traceback, uuid, os, time
+import urllib.request as urequest
 from lifecycle.data.db import SERVICE_INSTANCES_LIST
 from common.logs import LOG
 import config
@@ -146,8 +147,8 @@ def deploy_docker_compose(service, agent):
             LOG.warning("LIFECYCLE:Error when removing file: " + config.dic['WORKING_DIR_VOLUME'] + "/docker-compose.yml")
         # download docker-compose.yml
         try:
-            res = wget.download(location, config.dic['WORKING_DIR_VOLUME'] + "/docker-compose.yml")
-            LOG.debug("LIFECYCLE:  > wget download result: " + str(res))
+            res, _ = urequest.urlretrieve(location, config.dic['WORKING_DIR_VOLUME'] + "/docker-compose.yml")
+            LOG.debug("LIFECYCLE:  > download result: " + str(res))
         except:
             LOG.error("LIFECYCLE:Error when downloading file to: " + config.dic['WORKING_DIR_VOLUME'] + "/docker-compose.yml")
             return common.gen_response(500, "Exception: deploy_docker_compose(): Error when downloading file to WORKING_DIR_VOLUME",

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,11 +33,6 @@ docker==3.0.1
 #   BSD licence; http://www.pydblite.net/en/licence.html
 pydblite==3.0.4
 
-# wget
-#   https://bitbucket.org/techtonik/python-wget/src
-#   UNLICENSE; https://bitbucket.org/techtonik/python-wget/src/3001fd1b30aca7e5fe162c9193ccbb951dabb4ea/UNLICENSE
-wget==3.2
-
 # kubernetes
 #
 #


### PR DESCRIPTION
This adds support for `data:` URIs, which simplify my usage of the lifecycle manager. The `wget` library does not support them (and is unmaintained in general), so I've removed its only usage and used what Python 3.4+ provides out of the box.